### PR TITLE
Update Ubuntu build instructions (fixes #24)

### DIFF
--- a/_docs/getting-started/ubuntu.md
+++ b/_docs/getting-started/ubuntu.md
@@ -52,7 +52,6 @@ We test the latest code on
 sudo apt-get update
 sudo apt-get install -y --no-install-recommends \
       build-essential \
-      cmake \
       git \
       libgoogle-glog-dev \
       libgtest-dev \
@@ -71,16 +70,22 @@ sudo apt-get install -y --no-install-recommends \
 pip install --user \
       future \
       numpy \
-      protobuf
+      protobuf \
+      typing \
+      hypothesis
 ```
 
 > Note `libgflags2` is for Ubuntu 14.04. `libgflags-dev` is for Ubuntu 16.04.
 
 ```bash
 # for Ubuntu 14.04
-sudo apt-get install -y --no-install-recommends libgflags2
+sudo apt-get install -y --no-install-recommends \
+      libgflags2 \
+      cmake3
 # for Ubuntu 16.04
-sudo apt-get install -y --no-install-recommends libgflags-dev
+sudo apt-get install -y --no-install-recommends \
+      libgflags-dev \
+      cmake
 ```
 
 > If you have a GPU, follow [these additional steps](#install-with-gpu-support) before continuing.


### PR DESCRIPTION
Hi, as discussed in issue #24, I've updated the build instructions for Ubuntu. The pull request slightly differs from my suggestion in #24, because I realized that Ubuntu 16.04 ships CMake 3.x in the `cmake` package instead of the `cmake3` package, and because the suggested test for installations with GPU support (`caffe2/python/operator_test/activation_ops_test.py`) requires hypothesis to run.